### PR TITLE
Feature/skip auto config creations

### DIFF
--- a/app/models/wupee/notification_type.rb
+++ b/app/models/wupee/notification_type.rb
@@ -5,15 +5,4 @@ class Wupee::NotificationType < ActiveRecord::Base
   has_many :notification_type_configurations, foreign_key: :notification_type_id, dependent: :destroy
   has_many :notifications, foreign_key: :notification_type_id, dependent: :destroy
 
-  def self.create_configurations_for(*receivers)
-    class_eval do
-      receivers.each do |receiver|
-        after_create do
-          receiver.to_s.constantize.pluck(:id).each do |receiver_id|
-            Wupee::NotificationTypeConfiguration.create!(notification_type: self, receiver_type: receiver, receiver_id: receiver_id)
-          end
-        end
-      end
-    end
-  end
 end

--- a/lib/wupee.rb
+++ b/lib/wupee.rb
@@ -13,6 +13,5 @@ module Wupee
 
   def self.receivers=(klass)
     @@receivers = klass
-    Wupee::NotificationType.create_configurations_for(klass)
   end
 end

--- a/lib/wupee/notifier.rb
+++ b/lib/wupee/notifier.rb
@@ -51,6 +51,8 @@ module Wupee
       raise ArgumentError.new('receiver or receivers is missing') if @receiver_s.nil?
       raise ArgumentError.new('notif_type is missing') if @notification_type.nil?
 
+      create_necessary_configurations
+
       notif_type_configs = Wupee::NotificationTypeConfiguration.includes(:receiver).where(receiver: @receiver_s, notification_type: @notification_type)
 
       notif_type_configs.each do |notif_type_config|
@@ -62,6 +64,12 @@ module Wupee
         locals_interpolations = interpolate_vars(@locals, notification)
 
         send_email(notification, subject_interpolations, locals_interpolations) if notif_type_config.wants_email?
+      end
+    end
+
+    def create_necessary_configurations
+      @receiver_s.each do |receiver|
+        Wupee::NotificationTypeConfiguration.find_or_create_by! receiver: receiver, notification_type: @notification_type
       end
     end
 

--- a/spec/models/notification_type_configuration_spec.rb
+++ b/spec/models/notification_type_configuration_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Wupee::NotificationTypeConfiguration, type: :model do
     end
 
     it "validates uniqueness of [receiver, notification_type]" do
+      Wupee::NotificationTypeConfiguration.create(receiver: receiver, notification_type: notification_type)
       notification_type_conf_same = Wupee::NotificationTypeConfiguration.create(receiver: receiver, notification_type: notification_type)
       expect(notification_type_conf_same).to be_invalid
     end

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -30,18 +30,13 @@ RSpec.describe Wupee::NotificationType, type: :model do
     end
   end
 
-  context "class methods" do
-    it "has a method create_configurations_for which creates NotificationTypeConfiguration objects" do
-      expect { create :notification_type, name: "random_notif_type_2" }.to change { Wupee::NotificationTypeConfiguration.count }.by(User.count)
-    end
-  end
-
   context "associations" do
     it "destroys notification_type_configurations on destroy" do
       expect { notification_type.destroy! }.to change { Wupee::Notification.count }.by(-1)
     end
 
     it "destroys notifications on destroy" do
+      Wupee::NotificationTypeConfiguration.create! receiver: receiver, notification_type: notification_type
       expect { notification_type.destroy! }.to change { Wupee::NotificationTypeConfiguration.count }.by(-1)
     end
   end

--- a/spec/models/notifier_spec.rb
+++ b/spec/models/notifier_spec.rb
@@ -29,12 +29,15 @@ RSpec.describe Wupee::Notifier, type: :model do
     user_3 = create :user
     user_4 = create :user
 
+
+    user_1.notification_type_configurations.destroy_all
     Wupee::NotificationTypeConfiguration.find_by(receiver: user_2, notification_type: notif_type).update(value: :nothing)
     Wupee::NotificationTypeConfiguration.find_by(receiver: user_3, notification_type: notif_type).update(value: :email)
     Wupee::NotificationTypeConfiguration.find_by(receiver: user_4, notification_type: notif_type).update(value: :notification)
 
     wupee_notifier = Wupee::Notifier.new(receivers: [user_1, user_2, user_3, user_4], notif_type: notif_type)
 
+    expect { wupee_notifier.execute }.to change { Wupee::NotificationTypeConfiguration.count }.by(1)
     expect { wupee_notifier.execute }.to change { ActionMailer::Base.deliveries.size }.by(2)
     expect { wupee_notifier.execute }.to change { Wupee::Notification.where(is_read: true).count }.by(2)
     expect { wupee_notifier.execute }.to change { Wupee::Notification.count }.by(4)


### PR DESCRIPTION
When the users table is huge, trying to create configurations as part of notification_type creation is taking too long time. 

So, the new approach is to skip that and create configuration object in a lazy way i.e., before a notification is created.