### PR TITLE
Adjusting the migrations to make them Rails5 compliant

### DIFF
--- a/db/migrate/20151029113100_create_wupee_notification_types.rb
+++ b/db/migrate/20151029113100_create_wupee_notification_types.rb
@@ -1,4 +1,4 @@
-class CreateWupeeNotificationTypes < ActiveRecord::Migration
+class CreateWupeeNotificationTypes < ActiveRecord::Migration[5.0]
   def change
     create_table :wupee_notification_types do |t|
       t.string :name

--- a/db/migrate/20151029113101_create_wupee_notification_type_configurations.rb
+++ b/db/migrate/20151029113101_create_wupee_notification_type_configurations.rb
@@ -1,14 +1,13 @@
-class CreateWupeeNotificationTypeConfigurations < ActiveRecord::Migration
+class CreateWupeeNotificationTypeConfigurations < ActiveRecord::Migration[5.0]
   def change
     create_table :wupee_notification_type_configurations do |t|
-      t.belongs_to :notification_type
-      t.belongs_to :receiver, polymorphic: true
+      t.belongs_to :notification_type, index: { name: 'idx_wupee_notif_type_config_on_notification_type_id' }
+      t.belongs_to :receiver, polymorphic: true, index: { name: 'idx_wupee_notif_type_config_on_receiver_id' }
       t.integer :value, default: 0
       t.timestamps null: false
     end
 
     add_foreign_key :wupee_notification_type_configurations, :wupee_notification_types, column: :notification_type_id
-    add_index :wupee_notification_type_configurations, [:notification_type_id], name: "idx_wupee_notif_type_config_on_notification_type_id"
-    add_index :wupee_notification_type_configurations, [:receiver_type, :receiver_id], name: "idx_wupee_notif_typ_config_on_receiver_type_and_receiver_id"
+    add_index :wupee_notification_type_configurations, [:receiver_type, :receiver_id], name: 'idx_wupee_notif_typ_config_on_receiver_type_and_receiver_id'
   end
 end

--- a/db/migrate/20151029113107_create_wupee_notifications.rb
+++ b/db/migrate/20151029113107_create_wupee_notifications.rb
@@ -1,9 +1,8 @@
-class CreateWupeeNotifications < ActiveRecord::Migration
+class CreateWupeeNotifications < ActiveRecord::Migration[5.0]
   def change
     create_table :wupee_notifications do |t|
-      t.references :receiver, polymorphic: true
-      t.references :attached_object, polymorphic: true
-      t.belongs_to :notification_type
+      t.references :receiver, polymorphic: true, index: { name: 'idx_wupee_notifications_on_receiver_id' }
+      t.references :attached_object, polymorphic: true, index: { name: 'idx_wupee_notifications_on_attached_object_id' }
       t.integer :notification_type_id
       t.boolean :is_read, default: false
       t.boolean :is_sent, default: false
@@ -11,6 +10,7 @@ class CreateWupeeNotifications < ActiveRecord::Migration
       t.timestamps null: false
     end
 
+    add_index :wupee_notifications, :notification_type_id, name: 'idx_wupee_notifications_on_notification_type_id'
     add_foreign_key :wupee_notifications, :wupee_notification_types, column: :notification_type_id
   end
 end


### PR DESCRIPTION
- inheriting from ActiveRecord::Migration[5.0]
- preventing too long names on autogenerated indexes (the ones comming from the t.belongs_to and t.references statements)
- removing unused belongs_to "t.belongs_to :notification_type", because it is being overwritten by the t.integer :notification_type_id, which is later defined as a reference properly.